### PR TITLE
Refactor guard clauses to make code more readable

### DIFF
--- a/doozy/controllers/indexController.js
+++ b/doozy/controllers/indexController.js
@@ -15,27 +15,26 @@ module.exports = {
     var password = req.body.password.trim();
     var teamname = req.body.teamname.trim();
     if (username === '' || teamname === '' || password === '') {
-      res.status(400).send('Username, Password, and Teamname must be present');
-      return;
+      return res.status(400).send('Username, Password, and Teamname must be present');
     }
 
     User.findOne({username: username}, function(err, user) {
-      if (user) { res.status(400).send('Username exists'); return; }
+      if (user) return res.status(400).send('Username exists');
       var newUser = new User({
         username: username,
         password: password
       });
 
       newUser.save(function(err, newUser) {
-        if (err) { res.status(404).send(err); return; }
+        if (err) return res.status(404).send(err);
 
         Team.findOne({name: teamname}, function(err, team) {
-          if (err) { res.status(404).send(err); return; }
+          if (err) return res.status(404).send(err);
           team = team || new Team({name: teamname});
 
           team.users.push(newUser);
           team.save(function (err) {
-            if (err) { res.status(404).send(err); return; }
+            if (err) return res.status(404).send(err);
 
             res.status(201);
             sendJWT(newUser, res);
@@ -54,26 +53,18 @@ module.exports = {
     var password = req.body.password.trim();
     var teamname = req.body.teamname.trim();
     if (username === '' || teamname === '' || password === '') {
-      res.status(400).send('Username, Password, and Teamname must be present');
-      return;
+      return res.status(400).send('Username, Password, and Teamname must be present');
     }
 
     Team.findOne({name: teamname}, function(err, team) {
-      if (!team) {
-        res.status(401).send('Team does not exist');
-        return;
-      }
+      if (!team) return res.status(401).send('Team does not exist');
 
       User.findOne({username: username}, function(err, user) {
-        if (!user) {
-          res.status(401).send('Username does not exist');
-          return;
-        }
+        if (!user) return res.status(401).send('Username does not exist');
+
         user.comparePassword(password, function(match) {
-          if (!match) {
-            res.status(401).send('Password does not match');
-            return;
-          }
+          if (!match) return res.status(401).send('Password does not match');
+
           sendJWT(user, res);
         });
       });

--- a/doozy/controllers/projectController.js
+++ b/doozy/controllers/projectController.js
@@ -4,9 +4,7 @@ var Project = require('../models/project');
 module.exports = {
   allProjects: function (req, res, next) {
     Project.find({ }, function (err, projects) {
-      if (err) {
-        res.status(500).send(err);
-      }
+      if (err) return res.status(500).send(err);
 
       res.status(200).send(projects);
     });
@@ -17,22 +15,18 @@ module.exports = {
     var name = req.body.name.trim();
 
     Project.findOne({name: name}, function(err, project) { // FIXME?
-      if (err) { res.status(500).send(err); return; }
-      if (project) {
-        res.status(400).send('Project already exists');
-        return;
-      }
+      if (err) return res.status(500).send(err);
+      if (project) return res.status(400).send('Project already exists');
+
       var newProject = new Project({
         description: description,
         name: name
       });
 
       newProject.save(function(err, newProject) {
-        if (err) {
-          res.status(400).send(err);
-        } else {
-          res.sendStatus(201);
-        }
+        if (err) return res.status(400).send(err);
+
+        res.sendStatus(201);
       });
     });
   }

--- a/doozy/controllers/taskController.js
+++ b/doozy/controllers/taskController.js
@@ -16,24 +16,18 @@ module.exports = {
     var task = req.body.task;
 
     Task.findOne({_id: task}, function(err, task) {
-      if (err) {
-        res.sendStatus(404, err);
-        return;
-      }
+      if (err) return res.sendStatus(404, err);
+
       User.findOne({_id: user}, function(err, user) {
-        if (err) {
-          res.sendStatus(404, err);
-          return;
-        }
+        if (err) return res.sendStatus(404, err);
+
         task.users.push(user);
         user.tasks.push(task);
         task.save(function(err, t) {
           user.save(function(err, u) {
-            if (err) {
-              res.sendStatus(404, err);
-            } else {
-              res.sendStatus(200);
-            }
+            if (err) return res.sendStatus(404, err);
+
+            res.sendStatus(200);
           });
         });
       });
@@ -50,31 +44,25 @@ module.exports = {
       users: users
     });
     newTask.save(function(err, newTask) {
-      if (err) {
-        res.sendStatus(404, err);
-      } else {
-        res.sendStatus(201);
-      }
+      if (err) return res.sendStatus(404, err);
+
+      res.sendStatus(201);
     });
   },
 
   idToTask: function(req, res, next) {
     var taskId = mongoose.Types.ObjectId(req.params.id);
     Task.find({_id: taskId}).populate('users').exec(function(err, tasks) {
-      if (err) {
-        res.sendStatus(404, err);
-        return;
-      }
+      if (err) return res.sendStatus(404, err);
+
       res.status(200).send(tasks);
     });
   },
 
   updateTask: function(req, res, next) {
     Task.findOne({_id: req.body._id}, function(err, task) {
-      if (err) {
-        res.sendStatus(404, err);
-        return;
-      }
+      if (err) return res.sendStatus(404, err);
+
       task.name = req.body.name;
       task.description = req.body.description;
       task.isCompleted = req.body.isCompleted;
@@ -83,10 +71,8 @@ module.exports = {
       console.log(req.body.users);
 
       task.save(function (err, task) {
-        if (err) {
-          res.sendStatus(404, err);
-          return;
-        }
+        if (err) return res.sendStatus(404, err);
+
         res.sendStatus(205);
       });
     });

--- a/doozy/controllers/teamController.js
+++ b/doozy/controllers/teamController.js
@@ -12,20 +12,16 @@ module.exports = {
     var name = req.body.name.trim();
 
     Team.findOne({name: name}, function(err, team) {
-      if (team) {
-        res.status(400).send('Team exists');
-        return;
-      }
+      if (team) return res.status(400).send('Team exists');
+
       var newTeam = new Team({
         name: name,
       });
 
       newTeam.save(function(err, newTeam) {
-        if (err) {
-          res.sendStatus(404, err);
-        } else {
-          res.sendStatus(201);
-        }
+        if (err) return res.sendStatus(404, err);
+
+        res.sendStatus(201);
       });
     });
   },

--- a/doozy/controllers/userController.js
+++ b/doozy/controllers/userController.js
@@ -6,11 +6,9 @@ module.exports = {
   allUsers: function(req, res, next) {
     // send only _id and username
     User.find({}, '_id username', function(err, users) {
-      if (err) {
-        res.status(500).send();
-      } else {
-        res.status(200).send(users);
-      }
+      if (err) return res.status(500).send();
+
+      res.status(200).send(users);
     });
   },
 
@@ -20,20 +18,13 @@ module.exports = {
     var teamname = req.body.teamname.trim();
 
     Team.findOne({name: teamname}, function(err, team) {
-      if (!team) {
-        res.status(401).send('Team does not exist');
-        return;
-      }
+      if (!team) return res.status(401).send('Team does not exist');
+
       User.findOne({username: username}, function(err, user) {
-        if (!user) {
-          res.status(401).send('Username does not exist');
-          return;
-        }
+        if (!user) return res.status(401).send('Username does not exist');
+
         user.comparePassword(password, function(match) {
-          if (!match) {
-            res.status(401).send('Password does not match');
-            return;
-          }
+          if (!match) return res.status(401).send('Password does not match');
 
           user.remove();
           res.status(200).send('Deleted');

--- a/doozy/util.js
+++ b/doozy/util.js
@@ -5,11 +5,9 @@ var util = {
     var token = req.headers['x-access-token'];
     var user;
     if (!token) {
-      if (process.env.NODE_ENV === "test") {
-        token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJfX3YiOjAsInVzZXJuYW1lIjoibnVzZXIiLCJwYXNzd29yZCI6IiQyYSQxMCQ2aC81aUZ0bDVhQmxqc0pZNDZCZEx1b1VJbUV6OUN3c1NWcTQuUzcxaldHOFhpTnBITENqSyIsIl9pZCI6IjU2NGQyN2UyZjFmMWFlNDQzNzQ0MjYwMiIsInRhc2tzIjpbXX0.fdpdX10WOiM_31DWiBcaMYXae86XxQh7kfsQrg5x2qE";
-      } else {
-        return res.send(403); // send forbidden if a token is not provided
-      }
+      if (process.env.NODE_ENV !== "test") return res.send(403); // send forbidden if a token is not provided
+      
+      token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJfX3YiOjAsInVzZXJuYW1lIjoibnVzZXIiLCJwYXNzd29yZCI6IiQyYSQxMCQ2aC81aUZ0bDVhQmxqc0pZNDZCZEx1b1VJbUV6OUN3c1NWcTQuUzcxaldHOFhpTnBITENqSyIsIl9pZCI6IjU2NGQyN2UyZjFmMWFlNDQzNzQ0MjYwMiIsInRhc2tzIjpbXX0.fdpdX10WOiM_31DWiBcaMYXae86XxQh7kfsQrg5x2qE";
     }
     
     try {

--- a/test/integration/apitasks.js
+++ b/test/integration/apitasks.js
@@ -147,9 +147,7 @@ describe('Tasks API', function() {
         .expect(205)
         .then(function () {
           Task.findOne({name: 'test task two'}, function (err, foundTask) {
-            if (err) {
-              console.log("Err: ", err);
-            }
+            if (err) console.log("Err: ", err);
 
             expect(foundTask.isCompleted).to.equal(false);
             done();
@@ -167,9 +165,7 @@ describe('Tasks API', function() {
         .expect(205)
         .then(function () {
           Task.findOne({name: 'test task two'}, function (err, foundTask) {
-            if (err) {
-              console.log("Err: ", err);
-            }
+            if (err) console.log("Err: ", err);
 
             task = foundTask;
             expect(task.users).to.have.length(1);
@@ -188,9 +184,7 @@ describe('Tasks API', function() {
         .expect(205)
         .then(function () {
           Task.findOne({name: 'test task two'}, function (err, foundTask) {
-            if (err) {
-              console.log("Err: ", err);
-            }
+            if (err) console.log("Err: ", err);
 
             expect(foundTask.users).to.have.length(0);
             task.users.push(user._id);
@@ -201,9 +195,7 @@ describe('Tasks API', function() {
                 .expect(205)
                 .then(function () {
                   Task.findOne({name: 'test task two'}, function (err, foundTask) {
-                    if (err) {
-                      console.log("Err: ", err);
-                    }
+                    if (err) console.log("Err: ", err);
 
                     expect(foundTask.users).to.have.length(1);
                     done();
@@ -226,10 +218,10 @@ describe('Tasks API', function() {
           .expect(205)
           .then(function() {
             Task.findOne({name: 'test task two'}, function (err, foundTask) {
-              if (err) {
-                console.log("Err: ", err);
-              }
+              if (err) console.log("Err: ", err);
+
               expect(foundTask.users).to.have.length(0);
+
               request(app)
                 .post('/api/tasks/assign')
                 .send({
@@ -239,9 +231,7 @@ describe('Tasks API', function() {
                 .expect(200)
                 .then(function() {
                   Task.findOne({name: 'test task two'}, function (err, foundTask) {
-                    if (err) {
-                      console.log('err: ', err);
-                    }
+                    if (err) console.log('err: ', err);
 
                     expect(foundTask.users).to.have.length(1);
                     done();


### PR DESCRIPTION
It is a common (some argue best) practice to use this guard pattern:

`if (err) return errorHandler()`

rather than the more verbose:

`if (err) {
  errorHandler();
  return;
}`

which just clutters your code